### PR TITLE
adding example environment variable to config

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -12,6 +12,7 @@ index: interior-node:2222
 
 [containers.options]
 # This array of options is passed to 'run' if there are none in the TaskInfo.
+# Example: [ "-e", "SOME_KEY=SOME_VALUE" ]
 default: []
 # These options are passed to 'run' in addition to those in the TaskInfo.
 append: []


### PR DESCRIPTION
Just a one-liner to example.cfg to address the config issue in #10.
