### PR TITLE
Adding missing itertools import

### DIFF
--- a/deimos/containerizer/docker.py
+++ b/deimos/containerizer/docker.py
@@ -1,5 +1,6 @@
 import errno
 from fcntl import LOCK_EX, LOCK_NB, LOCK_SH, LOCK_UN
+from itertools import takewhile, dropwhile
 import logging
 import os
 import random


### PR DESCRIPTION
'takewhile' and 'dropwhile' were raising errors because of the missing import statement
