### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/deimos/logger.py
+++ b/deimos/logger.py
@@ -81,6 +81,13 @@ _initialized = False
 
 _settings = {}
 
-_null_handler = logging.NullHandler()
+try:
+  _null_handler = logging.NullHandler()
+except:
+  # Python 2.6 compatibility
+  class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+  _null_handler = NullHandler()
 
 root.addHandler(_null_handler)

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,24 @@ import sys
 
 version = "deimos/VERSION"
 
+def check_output(*popenargs, **kwargs):
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
 
 def sync_version():
     code = "git describe --tags --exact-match 2>/dev/null"
     try:
+        try: subprocess.check_output
+        except: subprocess.check_output = check_output
         v = subprocess.check_output(code, shell=True)
         with open(version, "w+") as h:
             h.write(v)


### PR DESCRIPTION
- subprocess.check_output()
- logging.NullHandler()

This should solve #9
